### PR TITLE
Use Pure Algorithm

### DIFF
--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -1,8 +1,7 @@
 #![allow(dead_code, unused_variables)]
 
-use crate::file_system::{Directory, Label};
+use crate::file_system::{Directory, Path};
 use crate::file_system::{DirectoryContents, File};
-use nonempty::NonEmpty;
 use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::rc::Rc;
@@ -26,20 +25,20 @@ pub struct Diff {
 }
 
 pub struct CreateFile {
-    pub path: NonEmpty<Label>,
+    pub path: Path,
 }
 
 pub struct DeleteFile {
-    pub path: NonEmpty<Label>,
+    pub path: Path,
 }
 
 pub struct MoveFile {
-    pub old_path: NonEmpty<Label>,
-    pub new_path: NonEmpty<Label>,
+    pub old_path: Path,
+    pub new_path: Path,
 }
 
 pub struct ModifiedFile {
-    pub path: NonEmpty<Label>,
+    pub path: Path,
     pub diff: FileDiff,
 }
 
@@ -59,10 +58,10 @@ impl Diff {
 
     // TODO: Direction of comparison is not obvious with this signature.
     // For now using conventional approach with the right being "newer".
-    pub fn diff(left: Directory, right: Directory) -> Result<Diff, DiffError> {
+    pub fn diff(left: Directory, right: Directory) -> Diff {
         let mut diff = Diff::new();
-        let path = Rc::new(RefCell::new(Vec::new()));
-        Diff::collect_diff(&left, &right, &path, &mut diff)?;
+        let path = Rc::new(RefCell::new(Path::root()));
+        Diff::collect_diff(&left, &right, &path, &mut diff);
 
         // TODO: Some of the deleted files may actually be moved (renamed) to one of the created files.
         // Finding out which of the deleted files were deleted and which were moved will probably require
@@ -70,15 +69,15 @@ impl Diff {
         // Final decision can be based on heuristics, e.g. the file can be considered moved,
         // if len(LCS) > 0,25 * min(size(d), size(c)), and deleted otherwise.
 
-        Ok(diff)
+        diff
     }
 
     fn collect_diff(
         old: &Directory,
         new: &Directory,
-        parent_path: &Rc<RefCell<Vec<Label>>>,
+        parent_path: &Rc<RefCell<Path>>,
         diff: &mut Diff,
-    ) -> Result<(), String> {
+    ) {
         // TODO: Consider storing directory contents in sorted order
         let old = get_sorted_contents(old);
         let new = get_sorted_contents(new);
@@ -94,11 +93,11 @@ impl Diff {
                     let cmp = new_entry.label().cmp(&old_entry.label());
                     match cmp {
                         Ordering::Greater => {
-                            diff.add_deleted_files(old_entry, parent_path)?;
+                            diff.add_deleted_files(old_entry, parent_path);
                             old_entry_opt = old_iter.next();
                         }
                         Ordering::Less => {
-                            diff.add_created_files(new_entry, parent_path)?;
+                            diff.add_created_files(new_entry, parent_path);
                             new_entry_opt = new_iter.next();
                         }
                         Ordering::Equal => {
@@ -115,19 +114,19 @@ impl Diff {
                                 }
                                 (File(new_file), SubDirectory(old_dir)) => {
                                     diff.add_created_file(new_file, parent_path);
-                                    diff.add_deleted_files(old_entry, parent_path)?;
+                                    diff.add_deleted_files(old_entry, parent_path);
                                     old_entry_opt = old_iter.next();
                                     new_entry_opt = new_iter.next();
                                 }
                                 (SubDirectory(new_dir), File(old_file)) => {
-                                    diff.add_created_files(new_entry, parent_path)?;
+                                    diff.add_created_files(new_entry, parent_path);
                                     diff.add_deleted_file(old_file, parent_path);
                                     old_entry_opt = old_iter.next();
                                     new_entry_opt = new_iter.next();
                                 }
                                 (SubDirectory(new_dir), SubDirectory(old_dir)) => {
                                     parent_path.borrow_mut().push(new_dir.label.clone());
-                                    Diff::collect_diff(&**old_dir, &**new_dir, parent_path, diff)?;
+                                    Diff::collect_diff(&**old_dir, &**new_dir, parent_path, diff);
                                     parent_path.borrow_mut().pop();
                                     old_entry_opt = old_iter.next();
                                     new_entry_opt = new_iter.next();
@@ -146,96 +145,77 @@ impl Diff {
                     }
                 }
                 (Some(old_entry), None) => {
-                    diff.add_deleted_files(old_entry, parent_path)?;
+                    diff.add_deleted_files(old_entry, parent_path);
                     old_entry_opt = old_iter.next();
                 }
                 (None, Some(new_entry)) => {
-                    diff.add_created_files(new_entry, parent_path)?;
+                    diff.add_created_files(new_entry, parent_path);
                     new_entry_opt = new_iter.next();
                 }
                 (None, None) => break,
             }
         }
-        Ok(())
     }
 
     // if entry is a file, then return this file,
     // or a list of files in the directory tree otherwise
     fn collect_files_from_entry<F, T>(
         entry: &DirectoryContents,
-        parent_path: &Rc<RefCell<Vec<Label>>>,
+        parent_path: &Rc<RefCell<Path>>,
         mapper: F,
-    ) -> Result<Vec<T>, String>
+    ) -> Vec<T>
     where
-        F: Fn(&File, Vec<Label>) -> Result<T, String> + Copy,
+        F: Fn(&File, Path) -> T + Copy,
     {
         match entry {
             DirectoryContents::SubDirectory(dir) => Diff::collect_files(dir, parent_path, mapper),
             DirectoryContents::File(file) => {
                 parent_path.borrow_mut().push(file.filename.clone());
-                let mapped = mapper(file, parent_path.borrow().to_vec())?;
+                let mapped = mapper(file, parent_path.borrow().to_owned());
                 parent_path.borrow_mut().pop();
-                Ok(vec![mapped])
+                vec![mapped]
             }
-            _ => Err(String::from("Unexpected entry type")),
+            DirectoryContents::Repo => vec![],
         }
     }
 
-    fn collect_files<F, T>(
-        dir: &Directory,
-        parent_path: &Rc<RefCell<Vec<Label>>>,
-        mapper: F,
-    ) -> Result<Vec<T>, String>
+    fn collect_files<F, T>(dir: &Directory, parent_path: &Rc<RefCell<Path>>, mapper: F) -> Vec<T>
     where
-        F: Fn(&File, Vec<Label>) -> Result<T, String> + Copy,
+        F: Fn(&File, Path) -> T + Copy,
     {
         let mut files: Vec<T> = Vec::new();
-        Diff::collect_files_inner(dir, parent_path, mapper, &mut files)?;
-        Ok(files)
+        Diff::collect_files_inner(dir, parent_path, mapper, &mut files);
+        files
     }
 
     fn collect_files_inner<'a, F, T>(
         dir: &'a Directory,
-        parent_path: &Rc<RefCell<Vec<Label>>>,
+        parent_path: &Rc<RefCell<Path>>,
         mapper: F,
         files: &mut Vec<T>,
-    ) -> Result<(), String>
-    where
-        F: Fn(&File, Vec<Label>) -> Result<T, String> + Copy,
+    ) where
+        F: Fn(&File, Path) -> T + Copy,
     {
         parent_path.borrow_mut().push(dir.label.clone());
         for entry in dir.entries.iter() {
             match entry {
                 DirectoryContents::SubDirectory(subdir) => {
                     parent_path.borrow_mut().push(subdir.label.clone());
-                    Diff::collect_files_inner(&**subdir, parent_path, mapper, files)?;
+                    Diff::collect_files_inner(&**subdir, parent_path, mapper, files);
                     parent_path.borrow_mut().pop();
                 }
                 DirectoryContents::File(file) => {
                     let mut path = parent_path.borrow().clone();
                     path.push(file.filename.clone());
-                    files.push(mapper(file, path)?);
+                    files.push(mapper(file, path));
                 }
                 DirectoryContents::Repo => { /* Skip repo directory */ }
             }
         }
         parent_path.borrow_mut().pop();
-        Ok(())
     }
 
-    fn convert_to_deleted(file: &File, path: Vec<Label>) -> Result<DeleteFile, String> {
-        Ok(DeleteFile {
-            path: NonEmpty::from_slice(&path).ok_or("Empty path")?,
-        })
-    }
-
-    fn convert_to_created(file: &File, path: Vec<Label>) -> Result<CreateFile, String> {
-        Ok(CreateFile {
-            path: NonEmpty::from_slice(&path).ok_or("Empty path")?,
-        })
-    }
-
-    fn add_modified_file(&mut self, file: &File, parent_path: &Rc<RefCell<Vec<Label>>>) {
+    fn add_modified_file(&mut self, file: &File, parent_path: &Rc<RefCell<Path>>) {
         // TODO: file diff can be calculated at this point
         // Use pijul's transaction diff as an inspiration?
         // https://nest.pijul.com/pijul_org/pijul:master/1468b7281a6f3785e9#anesp4Qdq3V
@@ -245,45 +225,35 @@ impl Diff {
         });
     }
 
-    fn add_created_file(&mut self, file: &File, parent_path: &Rc<RefCell<Vec<Label>>>) {
+    fn add_created_file(&mut self, file: &File, parent_path: &Rc<RefCell<Path>>) {
         self.created.push(CreateFile {
             path: Diff::build_non_empty_path(file, parent_path),
         });
     }
 
-    fn add_created_files(
-        &mut self,
-        dc: &DirectoryContents,
-        parent_path: &Rc<RefCell<Vec<Label>>>,
-    ) -> Result<(), String> {
+    fn add_created_files(&mut self, dc: &DirectoryContents, parent_path: &Rc<RefCell<Path>>) {
         let mut new_files: Vec<CreateFile> =
-            Diff::collect_files_from_entry(dc, &parent_path, Diff::convert_to_created)?;
+            Diff::collect_files_from_entry(dc, parent_path, |_, path| CreateFile { path });
         self.created.append(&mut new_files);
-        Ok(())
     }
 
-    fn add_deleted_file(&mut self, file: &File, parent_path: &Rc<RefCell<Vec<Label>>>) {
+    fn add_deleted_file(&mut self, file: &File, parent_path: &Rc<RefCell<Path>>) {
         self.deleted.push(DeleteFile {
             path: Diff::build_non_empty_path(file, parent_path),
         });
     }
 
-    fn add_deleted_files(
-        &mut self,
-        dc: &DirectoryContents,
-        parent_path: &Rc<RefCell<Vec<Label>>>,
-    ) -> Result<(), String> {
+    fn add_deleted_files(&mut self, dc: &DirectoryContents, parent_path: &Rc<RefCell<Path>>) {
         let mut new_files: Vec<DeleteFile> =
-            Diff::collect_files_from_entry(dc, &parent_path, Diff::convert_to_deleted)?;
+            Diff::collect_files_from_entry(dc, &parent_path, |_, path| DeleteFile { path });
         self.deleted.append(&mut new_files);
-        Ok(())
     }
 
-    fn build_non_empty_path(file: &File, parent_path: &Rc<RefCell<Vec<Label>>>) -> NonEmpty<Label> {
-        let mut path = parent_path.borrow().to_vec();
+    fn build_non_empty_path(file: &File, parent_path: &Rc<RefCell<Path>>) -> Path {
+        let mut path = parent_path.borrow().to_owned();
         path.push(file.filename.clone());
         // path is always non-empty, so we can use unwrap()
-        NonEmpty::from_slice(&path).unwrap()
+        path.clone()
     }
 }
 

--- a/src/file_system/mod.rs
+++ b/src/file_system/mod.rs
@@ -141,6 +141,10 @@ impl Path {
         self.0.push(label)
     }
 
+    pub fn pop(&mut self) -> Option<Label> {
+        self.0.pop()
+    }
+
     /// Iterator over the [`Label`](struct.Label.html)s in the `Path`.
     ///
     /// # Examples
@@ -404,7 +408,7 @@ impl DirectoryContents {
         match self {
             DirectoryContents::SubDirectory(dir) => Some(&dir.label),
             DirectoryContents::File(file) => Some(&file.filename),
-            _ => None
+            DirectoryContents::Repo => None,
         }
     }
 }


### PR DESCRIPTION
Here's what I was thinking for changes.

1. Convert all `Vec<Label>` -> `Path`, and we initialise with `Path::root()` in the `Rc`
2. Above removes any need to convert `Vec` to `NonEmpty` for creating `CreateFile` and `DeleteFile`.
3. The two combined remove any need for a `Result` in our return types.